### PR TITLE
JS Apply second argument is an array 

### DIFF
--- a/lib/midi-parser.js
+++ b/lib/midi-parser.js
@@ -305,7 +305,7 @@ Parser.prototype.readBytes = function(len) {
 
 Parser.prototype.readString = function(len) {
   var bytes = this.readBytes(len)
-  return String.fromCharCode.apply(null, bytes)
+  return String.fromCharCode.apply(null, [bytes])
 }
 
 Parser.prototype.readVarInt = function() {


### PR DESCRIPTION
JS Apply second argument is an array that contains arguments to apply to the function. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
With the actual code you get this error https://github.com/Tonejs/Midi/issues/69