### PR TITLE
Fix undefined tickPerFrame

### DIFF
--- a/lib/midi-writer.js
+++ b/lib/midi-writer.js
@@ -32,7 +32,7 @@ function writeHeader(w, header, numTracks) {
   if (header.timeDivision) {
     timeDivision = header.timeDivision
   } else if (header.ticksPerFrame && header.framesPerSecond) {
-    timeDivision = (-(header.framesPerSecond & 0xFF) << 8) | (ticksPerFrame & 0xFF)
+    timeDivision = (-(header.framesPerSecond & 0xFF) << 8) | (header.ticksPerFrame & 0xFF)
   } else if (header.ticksPerBeat) {
     timeDivision = header.ticksPerBeat & 0x7FFF
   }


### PR DESCRIPTION
https://github.com/carter-thaxton/midi-file/blob/9fa3684228763eb36320d12a8537046eb515e32a/lib/midi-writer.js#L35

Hello @carter-thaxton , it seems `tickPerFrame` is not defined.