### PR TITLE
Update deprecated Buffer() constructor call with Buffer.from()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var output = writeMidi(parsed)
 
 // Note that the output is simply an array of byte values.  writeFileSync wants a buffer, so this will convert accordingly.
 // Using native Javascript arrays makes the code portable to the browser or non-node environments
-var outputBuffer = new Buffer(output)
+var outputBuffer = Buffer.from(output)
 
 // Write to a new MIDI file.  it should match the original
 fs.writeFileSync('copy_star_wars.mid', outputBuffer)


### PR DESCRIPTION
Direct use of `Buffer()` is deprecated due to security concerns, and the use of static method `Buffer.from()` is recommended instead:

https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

This change updates the docs to provide an example using `Buffer.from()`

I did a quick test and I could verify that newer versions of Node.js throw a deprecation warning when using `Buffer()` directly, whilst `Buffer.from()` works the same without a deprecation notice.