### PR TITLE
Support non-standard 2-byte time signature message

### DIFF
--- a/lib/midi-parser.js
+++ b/lib/midi-parser.js
@@ -139,11 +139,16 @@ function parseTrack(data) {
             return event
           case 0x58:
             event.type = 'timeSignature'
-            if (length != 4) throw "Expected length for timeSignature event is 4, got " + length
+            if (length != 2 && length != 4) throw "Expected length for timeSignature event is 4 or 2, got " + length
             event.numerator = p.readUInt8()
             event.denominator = (1 << p.readUInt8())
-            event.metronome = p.readUInt8()
-            event.thirtyseconds = p.readUInt8()
+            if (length === 4) {
+              event.metronome = p.readUInt8()
+              event.thirtyseconds = p.readUInt8()
+            } else {
+              event.metronome = 0x24
+              event.thirtyseconds = 0x08
+            }
             return event
           case 0x59:
             event.type = 'keySignature'


### PR DESCRIPTION
Some MIDI files use non-standard time signature messages using 2 bytes instead of 4, which causes an error. The current PR allows such non standard messages, setting the `metronome` and `thirtyseconds` property values to their defaults.

Attached 2 files that cause the error: [MIDI files with 2-byte time signature.zip](https://github.com/carter-thaxton/midi-file/files/8749461/MIDI.files.with.2-byte.time.signature.zip)

